### PR TITLE
Ignore blank lines in indented blocks

### DIFF
--- a/src/parser.hera
+++ b/src/parser.hera
@@ -518,6 +518,7 @@ PopIndent
 
 Nested
   EOL &IndentedFurther -> $1
+  (EOL)+ &IndentedFurther -> $1  # Skip one or more empty lines
 
 IndentedFurther
   Indentation:indent ->
@@ -526,6 +527,7 @@ IndentedFurther
 
 SameLevel
   EOL &IndentedSame -> $1
+  (EOL)+ &IndentedSame -> $1
 
 IndentedSame
   Indentation:indent ->
@@ -534,6 +536,7 @@ IndentedSame
 
 NonstrictlyNested
   EOL &IndentedNotLess -> $1
+  (EOL)+ &IndentedNotLess -> $1
 
 IndentedNotLess
   Indentation:indent ->


### PR DESCRIPTION
This seems to resolve the issue in #9 .

Texlish Example used:

```
\usepackage{amsthm}

: proof
   \begin{quote}
   something

   something else
   \end{quote}
```

Before Changes (As pointed out in #9 ):

```
\begin{proof}
   \begin{quote}
   something
\end{proof}

   something else
   \end{quote}
```

After Changes:

```
\documentclass[11pt]{article}
\usepackage{amsthm}


\begin{document}
\begin{proof}
   \begin{quote}
   something

   something else
   \end{quote}
\end{proof}

\end{document}
```